### PR TITLE
fix-removed unwanted icons from document right header GO-18871

### DIFF
--- a/ios/QLPreviewControllerCustom.m
+++ b/ios/QLPreviewControllerCustom.m
@@ -66,7 +66,7 @@
     if (nvBar) {
         UINavigationItem *item = nvBar.items.firstObject;
         if (item.rightBarButtonItems.count > 1) {
-            UIBarButtonItem* button = item.rightBarButtonItems[1];
+            UIBarButtonItem* button = item.rightBarButtonItems[item.rightBarButtonItems.count - 1];
             NSArray * buttons = @[button];
             [item setRightBarButtonItems:buttons];
         }


### PR DESCRIPTION
Root cause: We are removing default buttons given by react-native-doc-viewer and implemented our own Share icon. while removing we are always removing first item from the list. but in different devices the index of default item is different. i.e the last item in the array.

Fix: solved by removing last index of the array (default button list) 